### PR TITLE
Close #2 Implement Spotify OAuth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'pry', :require => 'pry'
 gem 'figaro'
 gem 'faraday'
+gem 'omniauth-oauth2', '~> 1.3.1'
 gem 'omniauth-spotify'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
-    omniauth-oauth2 (1.4.0)
+    omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     omniauth-spotify (0.0.9)
@@ -252,6 +252,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (~> 3.0.5)
+  omniauth-oauth2 (~> 1.3.1)
   omniauth-spotify
   pg (~> 0.18)
   pry

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,8 @@
+class SessionsController < ApplicationController
+  def create
+    if user = User.find_or_create_from_auth(request.env['omniauth.auth'])
+      session[:user_id] = user.id
+    end
+    redirect_to root_path
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,4 +4,4 @@
   Amplify automatically generates a Spotify playlist based on a band or artist's previous show(s).
 </h4>
 
-<%= link_to "Login with Spotify", "/" %></center>
+<%= link_to "Log in with Spotify", login_path %></center>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :spotify, ENV['SPOTIFY_API_ID'], ENV['SPOTIFY_API_SECRET'], scope: 'playlist-read-private playlist-modify-private playlist-modify-public'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
-  root to: "home#index"
+  root "home#index"
+
+  get '/auth/spotify', as: :login
+  get '/auth/spotify/callback', to: 'sessions#create'
 end

--- a/spec/features/user_log_in_with_spotify_spec.rb
+++ b/spec/features/user_log_in_with_spotify_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'User logs in with Spotify' do
+  context 'new user grants access to Spotify profile' do
+    scenario 'they visit the root path' do
+      auth_data = {
+          'provider' => 'spotify',
+          'info'     => {
+            'display_name' => 'Fake User',
+            'id'           => '12345'
+          }
+        }
+
+      OmniAuth.config.mock_auth[:spotify] = auth_data
+
+      visit root_path
+
+      click_link "Log in with Spotify"
+
+      expect(page).to have_content("Log out")
+      expect(page).to have_content(auth_data['info']['display_name'])
+      expect(page).to_not have_content("Log in with Spotify")
+    end
+  end
+end


### PR DESCRIPTION
- Add user login spec
- Add Spotify authorization routes
- Add sessions controller
- Update 'Log in with Spotify' link path on Homepage
- Add omniauth initializer
- Set omniauth-oauth2 gem to version 1.3.1 to fix Invalid Redirect URI error